### PR TITLE
Fix artifacts require truffle v5 7 0

### DIFF
--- a/migrations/4_deploy_core.js
+++ b/migrations/4_deploy_core.js
@@ -15,13 +15,15 @@
  ******************************************************************************/
 
 const assert = require('assert')
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools')
 // CONFIG
 const CONFIG = require('../config/config.json')
 // FactoryDeployer
 const { TruffleDeployer: Deployer } = require('../utils/FactoryDeployer')
 // Token
-var RLC                     = artifacts.require('rlc-faucet-contract/RLC')
-var ERLCTokenSwap           = artifacts.require('@iexec/erlc/ERLCTokenSwap')
+// require ABIs previously generated at step 3
+var RLC                     = artifactsRequireFSThenNPM('rlc-faucet-contract/RLC')
+var ERLCTokenSwap           = artifactsRequireFSThenNPM('@iexec/erlc/ERLCTokenSwap')
 // ERC1538 core & delegates
 var ERC1538Proxy            = artifacts.require('@iexec/solidity/ERC1538Proxy')
 var ERC1538Update           = artifacts.require('@iexec/solidity/ERC1538UpdateDelegate')

--- a/migrations/5_deploy_ens.js
+++ b/migrations/5_deploy_ens.js
@@ -15,6 +15,7 @@
  ******************************************************************************/
 
 const assert = require('assert')
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools')
 // CONFIG
 const CONFIG = require('../config/config.json')
 // ENS
@@ -23,9 +24,11 @@ var FIFSRegistrar           = artifacts.require('@ensdomains/ens/FIFSRegistrar')
 var ReverseRegistrar        = artifacts.require('@ensdomains/ens/ReverseRegistrar.sol')
 var PublicResolver          = artifacts.require('@ensdomains/resolver/PublicResolver')
 // Core
-var RLC                     = artifacts.require('rlc-faucet-contract/RLC')
-var ERLCTokenSwap           = artifacts.require('@iexec/erlc/ERLCTokenSwap')
-var ERC1538Proxy            = artifacts.require('@iexec/solidity/ERC1538Proxy')
+// require ABIs previously generated at step 3
+var RLC                     = artifactsRequireFSThenNPM('rlc-faucet-contract/RLC')
+var ERLCTokenSwap           = artifactsRequireFSThenNPM('@iexec/erlc/ERLCTokenSwap')
+// require ABI previously generated at step 4
+var ERC1538Proxy            = artifactsRequireFSThenNPM('@iexec/solidity/ERC1538Proxy')
 var IexecInterfaceNative    = artifacts.require('IexecInterfaceNative')
 var IexecInterfaceToken     = artifacts.require('IexecInterfaceToken')
 var AppRegistry             = artifacts.require('AppRegistry')

--- a/migrations/6_whitelisting.js
+++ b/migrations/6_whitelisting.js
@@ -14,12 +14,16 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools')
 // CONFIG
 const CONFIG = require('../config/config.json')
 // Token
-var RLC           = artifacts.require('rlc-faucet-contract/RLC')
-var ERLCTokenSwap = artifacts.require('@iexec/erlc/ERLCTokenSwap')
-var ERC1538Proxy  = artifacts.require('@iexec/solidity/ERC1538Proxy')
+// require ABI previously generated at step 3
+var RLC           = artifactsRequireFSThenNPM('rlc-faucet-contract/RLC')
+var ERLCTokenSwap = artifactsRequireFSThenNPM('@iexec/erlc/ERLCTokenSwap')
+// Core
+// require ABI previously generated at step 4
+var ERC1538Proxy  = artifactsRequireFSThenNPM('@iexec/solidity/ERC1538Proxy')
 
 /*****************************************************************************
  *                                   Main                                    *

--- a/migrations/999_functions.js
+++ b/migrations/999_functions.js
@@ -14,9 +14,11 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools')
 // ERC1538 core & delegates
-var ERC1538Proxy = artifacts.require('@iexec/solidity/ERC1538Proxy')
-var ERC1538Query = artifacts.require('@iexec/solidity/ERC1538QueryDelegate')
+// require ABI previously generated at step 4
+var ERC1538Proxy = artifactsRequireFSThenNPM('@iexec/solidity/ERC1538Proxy')
+var ERC1538Query = artifactsRequireFSThenNPM('@iexec/solidity/ERC1538QueryDelegate')
 
 /*****************************************************************************
  *                                   Main                                    *

--- a/test/000_fullchain-ABILegacy.js
+++ b/test/000_fullchain-ABILegacy.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT              = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                     = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy            = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterfaceABILegacy = artifacts.require(`IexecInterface${DEPLOYMENT.asset}ABILegacy`);
 var AppRegistry             = artifacts.require("AppRegistry");
 var DatasetRegistry         = artifacts.require("DatasetRegistry");

--- a/test/000_fullchain.js
+++ b/test/000_fullchain.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/001_fullchain-1workers.js
+++ b/test/001_fullchain-1workers.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/002_fullchain-2workers.js
+++ b/test/002_fullchain-2workers.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/003_fullchain-3workers.js
+++ b/test/003_fullchain-3workers.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/004_fullchain-4workers.js
+++ b/test/004_fullchain-4workers.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/100_fullchain-5workers-1error.js
+++ b/test/100_fullchain-5workers-1error.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/200_fullchain-bot.js
+++ b/test/200_fullchain-bot.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/201_fullchain-bot-dualPool.js
+++ b/test/201_fullchain-bot-dualPool.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/300_fullchain-reopen.js
+++ b/test/300_fullchain-reopen.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/300_fullchain-reopen.js
+++ b/test/300_fullchain-reopen.js
@@ -431,6 +431,8 @@ contract('Fullchain', async (accounts) => {
 			it("clock fast forward", async () => {
 				target = Number((await IexecInstance.viewTask(taskid)).revealDeadline);
 				await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_increaseTime", params: [ target - (await web3.eth.getBlock("latest")).timestamp ], id: 0 }, () => {});
+                // Force block mine to make sure time increase is properly set
+				await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 0 }, () => {});
 			});
 		});
 

--- a/test/400_contributeAndCallback.js
+++ b/test/400_contributeAndCallback.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/ERC1154/callback.js
+++ b/test/ERC1154/callback.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/ERC1154/resultFor.js
+++ b/test/ERC1154/resultFor.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/ENSIntegration/ENSIntegration.js
+++ b/test/byContract/ENSIntegration/ENSIntegration.js
@@ -16,10 +16,11 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERLCSwap           = artifacts.require('@iexec/erlc/ERLCSwap');
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERLCTokenSwap      = artifactsRequireFSThenNPM('@iexec/erlc/ERLCTokenSwap')
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");
@@ -27,7 +28,7 @@ var WorkerpoolRegistry = artifacts.require("WorkerpoolRegistry");
 var App                = artifacts.require("App");
 var Dataset            = artifacts.require("Dataset");
 var Workerpool         = artifacts.require("Workerpool");
-var ENSRegistry        = artifacts.require("@ensdomains/ens/ENSRegistry");
+var ENSRegistry        = artifactsRequireFSThenNPM("@ensdomains/ens/ENSRegistry");
 
 const { BN, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 const tools     = require("../../../utils/tools");
@@ -57,7 +58,7 @@ contract('ENSIntegration', async (accounts) => {
 	var DatasetRegistryInstance    = null;
 	var WorkerpoolRegistryInstance = null;
 	var ENSInstance                = null;
-
+    
 	var categories = [];
 
 	/***************************************************************************
@@ -106,7 +107,7 @@ contract('ENSIntegration', async (accounts) => {
 				assert.equal(await enstools.resolve("rlc.iexec.eth"), (await RLC.deployed()).address);
 			}
 			if (DEPLOYMENT.asset == "Token" && !!process.env.KYC) {
-				assert.equal(await enstools.resolve("erlc.iexec.eth"), (await ERLCSwap.deployed()).address);
+				assert.equal(await enstools.resolve("erlc.iexec.eth"), (await ERLCTokenSwap.deployed()).address);
 			}
 			assert.equal(await enstools.resolve("core.v5.iexec.eth"       ), IexecInstance.address             );
 			assert.equal(await enstools.resolve("apps.v5.iexec.eth"       ), AppRegistryInstance.address       );

--- a/test/byContract/IexecAccessors/IexecAccessors.js
+++ b/test/byContract/IexecAccessors/IexecAccessors.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecCategoryManager/IexecCategoryManager.js
+++ b/test/byContract/IexecCategoryManager/IexecCategoryManager.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecERC20/IexecERC20.js
+++ b/test/byContract/IexecERC20/IexecERC20.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecEscrow/IexecEscrowNative.js
+++ b/test/byContract/IexecEscrow/IexecEscrowNative.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecEscrow/IexecEscrowToken.js
+++ b/test/byContract/IexecEscrow/IexecEscrowToken.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecMaintenance/configure.js
+++ b/test/byContract/IexecMaintenance/configure.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecOrderManagement/close.js
+++ b/test/byContract/IexecOrderManagement/close.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecOrderManagement/invalid.js
+++ b/test/byContract/IexecOrderManagement/invalid.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecOrderManagement/sign.js
+++ b/test/byContract/IexecOrderManagement/sign.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/00_matchorders.js
+++ b/test/byContract/IexecPoco/00_matchorders.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/01_initialize.js
+++ b/test/byContract/IexecPoco/01_initialize.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/02_contribute-tag.js
+++ b/test/byContract/IexecPoco/02_contribute-tag.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/02_contribute.js
+++ b/test/byContract/IexecPoco/02_contribute.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/03_reveal.js
+++ b/test/byContract/IexecPoco/03_reveal.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/04_finalize.js
+++ b/test/byContract/IexecPoco/04_finalize.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/04_finalize.js
+++ b/test/byContract/IexecPoco/04_finalize.js
@@ -369,6 +369,8 @@ contract('Poco', async (accounts) => {
 		target = Number((await IexecInstance.viewTask(tasks[3])).revealDeadline);
 
 		await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_increaseTime", params: [ target - (await web3.eth.getBlock("latest")).timestamp ], id: 0 }, () => {});
+        // Force block mine to make sure time increase is properly set
+        await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 0 }, () => {});
 	});
 
 	it("[4.3] Finalize - Correct (partial - wait)", async () => {

--- a/test/byContract/IexecPoco/05_reopen.js
+++ b/test/byContract/IexecPoco/05_reopen.js
@@ -343,6 +343,8 @@ contract('Poco', async (accounts) => {
 		target = Number((await IexecInstance.viewTask(tasks[2])).revealDeadline);
 
 		await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_increaseTime", params: [ target - (await web3.eth.getBlock("latest")).timestamp ], id: 0 }, () => {});
+        // Force block mine to make sure time increase is properly set
+        await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 0 }, () => {});
 	});
 
 	it("[5.2] Reopen - Correct", async () => {

--- a/test/byContract/IexecPoco/05_reopen.js
+++ b/test/byContract/IexecPoco/05_reopen.js
@@ -16,9 +16,10 @@
 
 //.wallet Conf.addressig
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/06_claim.js
+++ b/test/byContract/IexecPoco/06_claim.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/07_array.js
+++ b/test/byContract/IexecPoco/07_array.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/08_kitty.js
+++ b/test/byContract/IexecPoco/08_kitty.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecPoco/08_kitty.js
+++ b/test/byContract/IexecPoco/08_kitty.js
@@ -286,6 +286,8 @@ contract('Poco', async (accounts) => {
 		it("wait", async () => {
 			target = Number((await IexecInstance.viewTask(tasks[0])).finalDeadline);
 			await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_increaseTime", params: [ target - (await web3.eth.getBlock("latest")).timestamp ], id: 0 }, () => {});
+            // Force block mine to make sure time increase is properly set
+            await web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_mine", params: [], id: 0 }, () => {});
 		});
 
 		it("[8.3a] claim", async () => {

--- a/test/byContract/IexecPoco/verify.js
+++ b/test/byContract/IexecPoco/verify.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/IexecRelay/IexecRelay.js
+++ b/test/byContract/IexecRelay/IexecRelay.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");

--- a/test/byContract/registries/registies.js
+++ b/test/byContract/registries/registies.js
@@ -16,6 +16,7 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools');
 // Artefacts
 var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
 var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");

--- a/test/byContract/registries/resources.js
+++ b/test/byContract/registries/resources.js
@@ -16,9 +16,10 @@
 
 // Config
 var DEPLOYMENT         = require("../../../config/config.json").chains.default;
+const { artifactsRequireFSThenNPM } = require('../../../utils/migrate-tools')
 // Artefacts
-var RLC                = artifacts.require("rlc-faucet-contract/contracts/RLC");
-var ERC1538Proxy       = artifacts.require("iexec-solidity/ERC1538Proxy");
+var RLC                = artifactsRequireFSThenNPM("rlc-faucet-contract/RLC");
+var ERC1538Proxy       = artifactsRequireFSThenNPM("@iexec/solidity/ERC1538Proxy");
 var IexecInterface     = artifacts.require(`IexecInterface${DEPLOYMENT.asset}`);
 var AppRegistry        = artifacts.require("AppRegistry");
 var DatasetRegistry    = artifacts.require("DatasetRegistry");
@@ -26,7 +27,7 @@ var WorkerpoolRegistry = artifacts.require("WorkerpoolRegistry");
 var App                = artifacts.require("App");
 var Dataset            = artifacts.require("Dataset");
 var Workerpool         = artifacts.require("Workerpool");
-var ENSRegistry        = artifacts.require("@ensdomains/ens/ENSRegistry");
+var ENSRegistry        = artifactsRequireFSThenNPM("@ensdomains/ens/ENSRegistry");
 
 const { BN, expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 const tools     = require("../../../utils/tools");
@@ -36,7 +37,7 @@ const constants = require("../../../utils/constants");
 
 Object.extract = (obj, keys) => keys.map(key => obj[key]);
 
-contract('Ressources', async (accounts) => {
+contract('Resources', async (accounts) => {
 
 	assert.isAtLeast(accounts.length, 10, "should have at least 10 accounts");
 	let iexecAdmin      = null;

--- a/utils/migrate-tools.js
+++ b/utils/migrate-tools.js
@@ -1,0 +1,62 @@
+const { basename } = require('path');
+
+/*
+Since truffle v5.7.0, the ABI resolve algorithm has changed.
+- Before v5.7.0, the last valid ABI json file was selected
+- Since v5.7.0, the first valid ABI json file is selected 
+
+See changes here:
+Old version:
+https://github.com/trufflesuite/truffle/blob/28d00b8946b7e8d792f87bfe35c94af6cedc401b/packages/resolver/lib/resolver.ts#L64
+New version:
+https://github.com/trufflesuite/truffle/blob/c984fe37b740ee075ba93f2ebfd59b7cae4f0183/packages/resolver/lib/resolver.ts#L61
+
+Calling artifacts.require(<NPM path>) now throws an error when 
+deploying any new contract (RLC, ERLCTokenSwap, ERC1538Proxy etc.)
+
+Consequently, to keep the exact same behaviour and avoid any error thrown at migration time, 
+we must force truffle to select the last compiled ABI located in the truffle build directory
+instead of the NPM directory.
+ 
+For example, in the case of the RLC.json ABI:
+instead of executing : 
+    var RLC = artifacts.require('rlc-faucet-contract/RLC');
+ 
+first look for RLC.json in the build directory, then in the NPM directory : 
+    var RLC = artifacts.require('RLC');
+    if (!RLC) {
+        RLC = artifacts.require('rlc-faucet-contract/RLC');
+    }
+*/
+
+function artifactsRequireFSThenNPM(contractPath) 
+{
+    const name = basename(contractPath);
+    let contract;
+    try 
+    {
+        // ex: if contractPath == 'rlc-faucet-contract/RLC'
+        // executes: artifacts.require('RLC') to force the truffle 
+        // resolver to pick './build/contracts/RLC.json' instead of 
+        // './node_modules/rlc-faucet-contract/RLC.json'
+        contract = artifacts.require(name);
+    } 
+    catch (err) 
+    {
+        // ex: contractPath == 'RLC' : nothing else to do
+        if (name == contractPath) {
+            throw err;
+        }
+        // ex: if contractPath == 'rlc-faucet-contract/RLC'
+        // At this stage, the truffle resolver did not find the
+        // './build/contracts/RLC.json' ABI file, consequently
+        // we force the resolver to pick instead
+        // './node_modules/rlc-faucet-contract/RLC.json'
+        contract = artifacts.require(contractPath);
+    }
+    return contract;
+}
+
+module.exports = {
+    artifactsRequireFSThenNPM
+}


### PR DESCRIPTION
Hi iExec Team!. 👋 
Since truffle v5.7.0 `truffle migrate` is failing (#47). Consequently it is no more possible to deploy the PoCo contracts on a new chainid.  The following PR includes a patch that solves the issue by restoring the previous resolve mechanism that is expected in the various PoCo migration scripts.
The files impacted are:
- almost all the migration scripts
- almost all the test scripts.

**Tests**
✅ All the tests are running successfully using:
- ganache v7.8.0 hardfork london
- truffle v5.9.1

**Limitations**
🔴 `truffle migrate` is still failing when running evm **shanghai** (due to [factory.json](https://github.com/iExecBlockchainComputing/iexec-solidity/blob/master/deployment/factory.json))
You can have a look at the [workaround I developed to make it run on evm shanghai](https://github.com/0xalexbel/PoCo/tree/fix-evm-shanghai-deploy-factory) 

Hope it helps.