### PR TITLE
Upgrade compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNEXT
+- Upgrade Solidity Compiler to `v0.8.27`. (#130)
 - Fix configs native and token. (#129)
 - Bump dependencies: (#127)
     - `@openzeppelin/hardhat-upgrades`, `hardhat-dependency-compiler`, `web3`, 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -63,7 +63,7 @@ const bellecourNetworkConfig = {
 const config: HardhatUserConfig = {
     solidity: {
         compilers: [
-            { version: '0.8.21', settings: v8Settings }, // PoCo Boost (and ENS contracts >=0.8.4)
+            { version: '0.8.27', settings: v8Settings }, // v0.8 migrated PoCo modules (and ENS contracts >=0.8.4)
             { version: '0.6.12', settings }, // PoCo contracts
             { version: '0.4.11', settings }, // RLC contracts
         ],


### PR DESCRIPTION
Reminder :bulb::
- Next [solc v0.8.22](https://github.com/ethereum/solidity/releases/tag/v0.8.22) is only available from [hardhat@2.19.0](https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%402.19.0)