### PR TITLE
Migrate IexecAccessors tests to ethers v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
         run: npm run deploy
       - name: Test Timelock Deployment
         run: npm run deploy:timelock
+      # TODO: Remove before merging to develop
+      - name: Run test
+        run: npm run test test/byContract/IexecAccessors/**
       - name: Run coverage
         run: npm run coverage
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,15 @@ jobs:
         run: npm run build
       - name: Check storage layout
         run: npm run test-storage-layout
+      # TODO: Remove before merging to develop
+      - name: Run test
+        run: npm run test test/byContract/IexecAccessors/**
       - name: Run deployment
         # Basic deployment to make sure everything is ok.
         # Could be removed in the future if not relevant.
         run: npm run deploy
       - name: Test Timelock Deployment
         run: npm run deploy:timelock
-      # TODO: Remove before merging to develop
-      - name: Run test
-        run: npm run test test/byContract/IexecAccessors/**
       - name: Run coverage
         run: npm run coverage
       - name: Upload coverage reports to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Features
 - Migrate to Ethers v6:
     - Deployment scripts (#187)
+    - Tests
+        - IexecAccessors (#189)
 - Migrate scripts to TypeScript: (#184)
     - `getFunctionSignatures.js`, `common-test-snapshot.js`, `test-storage.js`, `timelock.js`
 - Migrated utility files to TypeScript : (#183)

--- a/test/byContract/IexecAccessors/IexecAccessors.test.ts
+++ b/test/byContract/IexecAccessors/IexecAccessors.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2020-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { AddressZero, HashZero } from '@ethersproject/constants';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import { ZeroAddress, ZeroHash } from 'ethers';
 import { deployments, ethers } from 'hardhat';
 import {
     IexecInterfaceNative,
@@ -141,10 +141,10 @@ describe('IexecAccessors', async () => {
         expect(deal.workerpool.price).to.equal(workerpoolPrice);
         expect(deal.trust).to.equal(1);
         expect(deal.category).to.equal(0);
-        expect(deal.tag).to.equal(HashZero); // Standard
+        expect(deal.tag).to.equal(ZeroHash); // Standard
         expect(deal.requester).to.equal(requester.address);
-        expect(deal.beneficiary).to.equal(AddressZero);
-        expect(deal.callback).to.equal(AddressZero);
+        expect(deal.beneficiary).to.equal(ZeroAddress);
+        expect(deal.callback).to.equal(ZeroAddress);
         expect(deal.params).to.equal('');
         expect(deal.startTime).to.be.greaterThan(0);
         expect(deal.botFirst).to.equal(0);
@@ -187,11 +187,11 @@ describe('IexecAccessors', async () => {
         expect(task.contributionDeadline).to.equal(startTime + timeRef * contributionDeadlineRatio);
         expect(task.revealDeadline).to.equal(0);
         expect(task.finalDeadline).to.equal(startTime + timeRef * finalDeadlineRatio);
-        expect(task.consensusValue).to.equal(HashZero);
+        expect(task.consensusValue).to.equal(ZeroHash);
         expect(task.revealCounter).to.equal(0);
         expect(task.winnerCounter).to.equal(0);
         expect(task.contributors.length).to.equal(0);
-        expect(task.resultDigest).to.equal(HashZero);
+        expect(task.resultDigest).to.equal(ZeroHash);
         expect(task.results).to.equal('0x');
         expect(task.resultsTimestamp).to.equal(0);
         expect(task.resultsCallback).to.equal('0x');
@@ -205,7 +205,7 @@ describe('IexecAccessors', async () => {
         expect(contribution.status).to.equal(ContributionStatusEnum.CONTRIBUTED);
         expect(contribution.resultHash.length).to.equal(66);
         expect(contribution.resultSeal.length).to.equal(66);
-        expect(contribution.enclaveChallenge).to.equal(AddressZero);
+        expect(contribution.enclaveChallenge).to.equal(ZeroAddress);
         expect(contribution.weight).to.equal(1);
     });
 

--- a/test/byContract/IexecAccessors/IexecAccessors.test.ts
+++ b/test/byContract/IexecAccessors/IexecAccessors.test.ts
@@ -281,6 +281,7 @@ describe('IexecAccessors', async () => {
     it('eip712domainSeparator', async function () {
         expect(await iexecPoco.eip712domain_separator()).equal(
             await hashDomain({
+                // TODO use IexecWrapper.getDomain() (with some modifications).
                 name: 'iExecODB',
                 version: '5.0.0',
                 chainId: (await ethers.provider.getNetwork()).chainId,

--- a/test/byContract/IexecAccessors/IexecAccessors.test.ts
+++ b/test/byContract/IexecAccessors/IexecAccessors.test.ts
@@ -183,6 +183,7 @@ describe('IexecAccessors', async () => {
         expect(task.status).to.equal(TaskStatusEnum.ACTIVE);
         expect(task.dealid).to.equal(dealId);
         expect(task.idx).to.equal(taskIndex);
+        expect(task.timeref).to.equal(timeRef);
         expect(task.contributionDeadline).to.equal(startTime + timeRef * contributionDeadlineRatio);
         expect(task.revealDeadline).to.equal(0);
         expect(task.finalDeadline).to.equal(startTime + timeRef * finalDeadlineRatio);

--- a/test/byContract/IexecAccessors/IexecAccessorsABILegacy.test.ts
+++ b/test/byContract/IexecAccessors/IexecAccessorsABILegacy.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AddressZero } from '@ethersproject/constants';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {

--- a/test/byContract/IexecAccessors/IexecAccessorsABILegacy.test.ts
+++ b/test/byContract/IexecAccessors/IexecAccessorsABILegacy.test.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2020-2024 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
+// SPDX-FileCopyrightText: 2020-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { AddressZero } from '@ethersproject/constants';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import { ZeroAddress } from 'ethers';
 import { ethers } from 'hardhat';
 import {
     IexecInterfaceNative,
@@ -176,7 +176,7 @@ describe('IexecAccessorsABILegacy', function () {
         expect(contribution[0]).to.equal(ContributionStatusEnum.CONTRIBUTED);
         expect(contribution[1]).to.equal(resultHash);
         expect(contribution[2]).to.equal(resultSeal);
-        expect(contribution[3]).to.equal(AddressZero); // enclaveChallenge
+        expect(contribution[3]).to.equal(ZeroAddress); // enclaveChallenge
     });
 
     it('[ABILegacy] Should return category', async function () {

--- a/test/byContract/IexecMaintenance/IexecMaintenance.test.ts
+++ b/test/byContract/IexecMaintenance/IexecMaintenance.test.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2020-2024 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
+// SPDX-FileCopyrightText: 2020-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { HashZero as hashZero } from '@ethersproject/constants';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, setStorageAt } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import { TypedDataEncoder, ZeroHash } from 'ethers';
 import { ethers } from 'hardhat';
 import {
     IexecInterfaceNative,
@@ -197,7 +197,7 @@ describe('Maintenance', async () => {
     });
 
     async function clearDomainSeparator() {
-        await setDomainSeparatorInStorage(hashZero);
+        await setDomainSeparatorInStorage(ZeroHash);
     }
 
     async function setDomainSeparatorInStorage(domainSeparator: string) {
@@ -213,7 +213,7 @@ describe('Maintenance', async () => {
 
 //TODO: Move to utils
 export async function hashDomain(domain: IexecLibOrders_v5.EIP712DomainStructOutput) {
-    return ethers.TypedDataEncoder.hashDomain({
+    return TypedDataEncoder.hashDomain({
         name: domain.name,
         version: domain.version,
         chainId: domain.chainId,

--- a/test/byContract/IexecMaintenance/IexecMaintenance.test.ts
+++ b/test/byContract/IexecMaintenance/IexecMaintenance.test.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { HashZero as hashZero } from '@ethersproject/constants';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, setStorageAt } from '@nomicfoundation/hardhat-network-helpers';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import {
@@ -120,9 +120,9 @@ describe('Maintenance', async () => {
             await expect(iexecPoco.importScore(worker.address)).to.be.revertedWithoutReason();
         });
         it('Should not import score when already imported', async () => {
-            const workerScoreImportedSlot = ethers.utils.hexStripZeros(
-                ethers.utils.keccak256(
-                    ethers.utils.defaultAbiCoder.encode(
+            const workerScoreImportedSlot = ethers.stripZerosLeft(
+                ethers.keccak256(
+                    ethers.AbiCoder.defaultAbiCoder().encode(
                         ['address', 'uint256'],
                         [
                             worker.address,
@@ -211,8 +211,9 @@ describe('Maintenance', async () => {
     }
 });
 
-async function hashDomain(domain: IexecLibOrders_v5.EIP712DomainStructOutput) {
-    return ethers.utils._TypedDataEncoder.hashDomain({
+//TODO: Move to utils
+export async function hashDomain(domain: IexecLibOrders_v5.EIP712DomainStructOutput) {
+    return ethers.TypedDataEncoder.hashDomain({
         name: domain.name,
         version: domain.version,
         chainId: domain.chainId,

--- a/test/utils/IexecWrapper.ts
+++ b/test/utils/IexecWrapper.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2024 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
+import { LogDescription } from '@ethersproject/abi';
 import { TypedDataDomain } from '@ethersproject/abstract-signer';
 import { AddressZero } from '@ethersproject/constants';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { BigNumber, ContractReceipt } from 'ethers';
+import { ContractTransactionReceipt, Log } from 'ethers';
 import hre, { ethers } from 'hardhat';
 import config from '../../config/config.json';
 import {
@@ -113,12 +114,12 @@ export class IexecWrapper {
      * @returns total amount to stake by the scheduler
      */
     async computeSchedulerDealStake(workerpoolPrice: number, volume: number): Promise<number> {
-        const stakeRatio = (
+        const stakeRatio = Number(
             await IexecAccessors__factory.connect(
                 this.proxyAddress,
                 this.accounts.anyone,
-            ).workerpool_stake_ratio()
-        ).toNumber();
+            ).workerpool_stake_ratio(),
+        );
         return Math.floor((workerpoolPrice * stakeRatio) / 100) * volume;
     }
 
@@ -256,19 +257,18 @@ export class IexecWrapper {
         const datasetOrder = orders.dataset;
         const workerpoolOrder = orders.workerpool;
         const requestOrder = orders.requester;
-        const taskIndex = (
-            await IexecAccessors__factory.connect(this.proxyAddress, ethers.provider).viewConsumed(
-                this.hashOrder(requestOrder),
-            )
-        ).toNumber();
+        const taskIndex = await IexecAccessors__factory.connect(
+            this.proxyAddress,
+            ethers.provider,
+        ).viewConsumed(this.hashOrder(requestOrder));
         const dealId = getDealId(this.domain, requestOrder, taskIndex);
         const taskId = getTaskId(dealId, taskIndex);
-        const volume = (
+        const volume = Number(
             await IexecPocoAccessors__factory.connect(
                 this.proxyAddress,
                 ethers.provider,
-            ).computeDealVolume(appOrder, datasetOrder, workerpoolOrder, requestOrder)
-        ).toNumber();
+            ).computeDealVolume(appOrder, datasetOrder, workerpoolOrder, requestOrder),
+        );
         const taskPrice =
             Number(appOrder.appprice) +
             Number(datasetOrder.datasetprice) +
@@ -310,12 +310,12 @@ export class IexecWrapper {
                 this.accounts.appProvider.address,
                 'my-app',
                 'APP_TYPE_0',
-                ethers.constants.HashZero,
-                ethers.constants.HashZero,
-                ethers.constants.HashZero,
+                ethers.ZeroHash,
+                ethers.ZeroHash,
+                ethers.ZeroHash,
             )
             .then((tx) => tx.wait());
-        return await extractRegistryEntryAddress(appReceipt, appRegistry.address);
+        return await extractRegistryEntryAddress(appReceipt, await appRegistry.getAddress());
     }
 
     async createDataset() {
@@ -328,11 +328,14 @@ export class IexecWrapper {
             .createDataset(
                 this.accounts.datasetProvider.address,
                 'my-dataset',
-                ethers.constants.HashZero,
-                ethers.constants.HashZero,
+                ethers.ZeroHash,
+                ethers.ZeroHash,
             )
             .then((tx) => tx.wait());
-        return await extractRegistryEntryAddress(datasetReceipt, datasetRegistry.address);
+        return await extractRegistryEntryAddress(
+            datasetReceipt,
+            await datasetRegistry.getAddress(),
+        );
     }
 
     /**
@@ -424,7 +427,7 @@ export class IexecWrapper {
             ethers.provider,
         )
             .viewDeal(dealId)
-            .then((deal) => deal.workerStake.toNumber());
+            .then((deal) => Number(deal.workerStake));
         const { resultHash, resultSeal } = buildResultHashAndResultSeal(
             taskId,
             resultDigest,
@@ -467,7 +470,10 @@ export class IexecWrapper {
         const workerpoolReceipt = await workerpoolRegistry
             .createWorkerpool(this.accounts.scheduler.address, 'my-workerpool')
             .then((tx) => tx.wait());
-        return await extractRegistryEntryAddress(workerpoolReceipt, workerpoolRegistry.address);
+        return await extractRegistryEntryAddress(
+            workerpoolReceipt,
+            await workerpoolRegistry.getAddress(),
+        );
     }
 
     async getInitialFrozens(accounts: SignerWithAddress[]) {
@@ -514,16 +520,77 @@ export class IexecWrapper {
  * @returns address of the entry in checksum format.
  */
 async function extractRegistryEntryAddress(
-    receipt: ContractReceipt,
+    receipt: ContractTransactionReceipt | null,
     registryInstanceAddress: string,
 ): Promise<string> {
-    const events = extractEventsFromReceipt(receipt, registryInstanceAddress, 'Transfer');
-    if (events && events[0].args) {
-        const lowercaseAddress = ethers.utils.hexZeroPad(
-            BigNumber.from(events[0].args['tokenId']).toHexString(),
-            20,
-        );
-        return ethers.utils.getAddress(lowercaseAddress);
+    if (!receipt) {
+        throw new Error('Undefined tx receipt');
     }
-    return '';
+    const eventName = 'Transfer';
+    const eventAbi = [
+        'event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)',
+    ];
+    const events = extractEventsFromReceipt(receipt, registryInstanceAddress, eventName, eventAbi);
+    if (events.length === 0) {
+        throw new Error('No event extracted from registry tx');
+    }
+    // Get registry address from event.
+    const lowercaseAddress = ethers.zeroPadValue(
+        ethers.toBeHex(BigInt(events[0].args.tokenId)),
+        20,
+    );
+    // To checksum address.
+    return ethers.getAddress(lowercaseAddress);
+}
+
+/**
+ * Extract a specific event of a contract from tx receipt.
+ * @param txReceipt
+ * @param address
+ * @param eventName
+ * @param eventAbi
+ * @returns array of events or empty array.
+ */
+function extractEventsFromReceipt(
+    txReceipt: ContractTransactionReceipt,
+    address: string,
+    eventName: string,
+    eventAbi: string[],
+): LogDescription[] {
+    return extractEvents(txReceipt.logs, address, eventName, eventAbi);
+}
+
+/**
+ * Extract a specific event of a contract from tx logs.
+ * @param logs
+ * @param address
+ * @param eventName
+ * @param eventAbi
+ * @returns array of events or empty array.
+ */
+function extractEvents(
+    logs: Log[],
+    address: string,
+    eventName: string,
+    eventAbi: string[],
+): LogDescription[] {
+    const eventInterface = new ethers.Interface(eventAbi);
+    const event = eventInterface.getEvent(eventName);
+    if (!event) {
+        throw new Error('Event name and abi mismatch');
+    }
+    const eventId = event.topicHash;
+    let extractedEvents = logs
+        // Get logs of the target contract.
+        .filter((log) => log.address === address && log.topics.includes(eventId))
+        // Parse logs to events.
+        .map((log) => eventInterface.parseLog(log))
+        // Get events with the target name.
+        .filter((event) => event && event.name === eventName);
+    // Get only non null elements.
+    // Note: using .filter(...) returns (LogDescription | null)[]
+    // which is not desired.
+    const events: LogDescription[] = [];
+    extractedEvents.forEach((element) => element && events.push(element));
+    return events;
 }

--- a/test/utils/IexecWrapper.ts
+++ b/test/utils/IexecWrapper.ts
@@ -1,12 +1,15 @@
-// SPDX-FileCopyrightText: 2024 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
+// SPDX-FileCopyrightText: 2024-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { LogDescription } from '@ethersproject/abi';
-import { TypedDataDomain } from '@ethersproject/abstract-signer';
-import { AddressZero } from '@ethersproject/constants';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { ContractTransactionReceipt, Log } from 'ethers';
+import {
+    ContractTransactionReceipt,
+    Log,
+    LogDescription,
+    TypedDataDomain,
+    ZeroAddress,
+} from 'ethers';
 import hre, { ethers } from 'hardhat';
 import config from '../../config/config.json';
 import {
@@ -432,7 +435,7 @@ export class IexecWrapper {
             resultDigest,
             contributor,
         );
-        const enclaveAddress = useEnclave ? this.accounts.enclave.address : AddressZero;
+        const enclaveAddress = useEnclave ? this.accounts.enclave.address : ZeroAddress;
         const enclaveSignature = useEnclave
             ? await buildAndSignPocoClassicEnclaveMessage(
                   resultHash,

--- a/test/utils/IexecWrapper.ts
+++ b/test/utils/IexecWrapper.ts
@@ -44,7 +44,6 @@ import {
     getTaskId,
     setNextBlockTimestamp,
 } from '../../utils/poco-tools';
-import { extractEventsFromReceipt } from '../../utils/tools';
 const DEPLOYMENT_CONFIG = config.chains.default;
 
 export class IexecWrapper {

--- a/utils/createOrders.ts
+++ b/utils/createOrders.ts
@@ -168,7 +168,7 @@ export function createEmptyDatasetOrder(): IexecLibOrders_v5.DatasetOrderStruct 
  * Create an order operation from an existing order.
  */
 export function createOrderOperation<OrderType>(order: OrderType, operation: OrderOperationEnum) {
-    return { order, operation: BigNumber.from(operation), sign: constants.NULL.SIGNATURE };
+    return { order, operation: Number(operation), sign: constants.NULL.SIGNATURE };
 }
 
 export function buildOrders(matchOrdersArgs: MatchOrdersArgs) {
@@ -263,7 +263,7 @@ export function buildDomain(domain?: TypedDataDomain | undefined) {
             verifyingContract: '0x0000000000000000000000000000000000000001',
         }; // testing purposes
     }
-    const domainSeparator = ethers.utils._TypedDataEncoder.hashDomain(domain);
+    const domainSeparator = ethers.TypedDataEncoder.hashDomain(domain);
     return { domain, domainSeparator };
 }
 

--- a/utils/createOrders.ts
+++ b/utils/createOrders.ts
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { BigNumber } from '@ethersproject/bignumber';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { TypedDataDomain, TypedDataEncoder } from 'ethers';
 import { IexecLibOrders_v5 } from '../typechain';
@@ -94,7 +93,7 @@ export class IexecOrders {
 
 export interface OrderOperation {
     order: Record<string, any>;
-    operation: BigNumber;
+    operation: number;
     sign: string;
 }
 

--- a/utils/createOrders.ts
+++ b/utils/createOrders.ts
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2023-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { TypedDataDomain } from '@ethersproject/abstract-signer';
 import { BigNumber } from '@ethersproject/bignumber';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { TypedDataDomain, TypedDataEncoder } from 'ethers';
 import { IexecLibOrders_v5 } from '../typechain';
 import * as constants from './constants';
 import { hashStruct, signStruct } from './odb-tools';
@@ -263,7 +262,7 @@ export function buildDomain(domain?: TypedDataDomain | undefined) {
             verifyingContract: '0x0000000000000000000000000000000000000001',
         }; // testing purposes
     }
-    const domainSeparator = ethers.TypedDataEncoder.hashDomain(domain);
+    const domainSeparator = TypedDataEncoder.hashDomain(domain);
     return { domain, domainSeparator };
 }
 

--- a/utils/odb-tools.ts
+++ b/utils/odb-tools.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2020-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { TypedDataDomain, TypedDataField, ethers } from 'ethers';
+import { TypedDataDomain, TypedDataEncoder, TypedDataField, ethers } from 'ethers';
 import hre from 'hardhat';
 
 interface WalletInfo {
@@ -165,5 +165,5 @@ export function hashStruct(
         [primaryType]: TYPES[primaryType],
     };
 
-    return ethers.TypedDataEncoder.hash(typedDataDomain, types, message);
+    return TypedDataEncoder.hash(typedDataDomain, types, message);
 }

--- a/utils/odb-tools.ts
+++ b/utils/odb-tools.ts
@@ -132,7 +132,7 @@ async function eth_signTypedData(
         }
 
         signerPromise
-            .then((signer) => signer._signTypedData(typedDataDomain, types, message))
+            .then((signer) => signer.signTypedData(typedDataDomain, types, message))
             .then(resolve)
             .catch(reject);
     });
@@ -165,5 +165,5 @@ export function hashStruct(
         [primaryType]: TYPES[primaryType],
     };
 
-    return ethers.utils._TypedDataEncoder.hash(typedDataDomain, types, message);
+    return ethers.TypedDataEncoder.hash(typedDataDomain, types, message);
 }

--- a/utils/poco-tools.ts
+++ b/utils/poco-tools.ts
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023-2024 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
+// SPDX-FileCopyrightText: 2023-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { TypedDataDomain } from '@ethersproject/abstract-signer';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { TypedDataDomain } from 'ethers';
 import { ethers } from 'hardhat';
 import { IexecLibOrders_v5 } from '../typechain';
 import { hashOrder } from './createOrders';

--- a/utils/poco-tools.ts
+++ b/utils/poco-tools.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TypedDataDomain } from '@ethersproject/abstract-signer';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { ethers } from 'hardhat';
 import { IexecLibOrders_v5 } from '../typechain';
 import { hashOrder } from './createOrders';
@@ -85,14 +85,14 @@ export function getDealId(
     requestOrder: IexecLibOrders_v5.RequestOrderStruct,
     firstTaskIndex: number = 0,
 ): string {
-    return ethers.utils.solidityKeccak256(
+    return ethers.solidityPackedKeccak256(
         ['bytes32', 'uint256'],
         [hashOrder(domain, requestOrder), firstTaskIndex],
     );
 }
 
 export function getTaskId(dealId: string, taskIndex: number): string {
-    return ethers.utils.solidityKeccak256(['bytes32', 'uint256'], [dealId, taskIndex]);
+    return ethers.solidityPackedKeccak256(['bytes32', 'uint256'], [dealId, taskIndex]);
 }
 
 export async function buildAndSignContributionAuthorizationMessage(
@@ -110,15 +110,15 @@ function buildContributionAuthorizationMessage(
     taskId: string,
     enclaveAddress: string,
 ) {
-    return ethers.utils.solidityKeccak256(
+    return ethers.solidityPackedKeccak256(
         ['address', 'bytes32', 'address'],
         [workerAddress, taskId, enclaveAddress],
     );
 }
 
 export function buildUtf8ResultAndDigest(resultPayload: string) {
-    const results = ethers.utils.toUtf8Bytes(resultPayload);
-    const resultDigest = ethers.utils.keccak256(results);
+    const results = ethers.toUtf8Bytes(resultPayload);
+    const resultDigest = ethers.keccak256(results);
     return { results, resultDigest };
 }
 
@@ -146,16 +146,16 @@ export function buildResultCallbackAndDigestForIntegerOracle(
     oracleCallDate: Date,
     oracleCallValue: number,
 ) {
-    const resultsCallback = ethers.utils.solidityPack(
+    const resultsCallback = ethers.solidityPacked(
         ['uint256', 'uint256'],
         [oracleCallDate.getTime(), oracleCallValue],
     );
-    const callbackResultDigest = ethers.utils.keccak256(resultsCallback);
+    const callbackResultDigest = ethers.keccak256(resultsCallback);
     return { resultsCallback, callbackResultDigest };
 }
 
 export function buildResultHash(taskId: string, resultDigest: string) {
-    return ethers.utils.solidityKeccak256(['bytes32', 'bytes'], [taskId, resultDigest]);
+    return ethers.solidityPackedKeccak256(['bytes32', 'bytes'], [taskId, resultDigest]);
 }
 
 export function buildResultHashAndResultSeal(
@@ -164,7 +164,7 @@ export function buildResultHashAndResultSeal(
     worker: SignerWithAddress,
 ) {
     const resultHash = buildResultHash(taskId, resultDigest);
-    const resultSeal = ethers.utils.solidityKeccak256(
+    const resultSeal = ethers.solidityPackedKeccak256(
         ['address', 'bytes32', 'bytes'],
         [worker.address, taskId, resultDigest],
     );
@@ -181,7 +181,7 @@ export async function buildAndSignPocoClassicEnclaveMessage(
 ) {
     return await signMessage(
         enclave,
-        ethers.utils.solidityKeccak256(['bytes32', 'bytes32'], [resultHash, resultSeal]),
+        ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [resultHash, resultSeal]),
     );
 }
 
@@ -200,14 +200,14 @@ export async function buildAndSignEnclaveMessage(
 }
 
 function buildEnclaveMessage(workerAddress: string, taskId: string, resultDigest: string) {
-    return ethers.utils.solidityKeccak256(
+    return ethers.solidityPackedKeccak256(
         ['address', 'bytes32', 'bytes32'],
         [workerAddress, taskId, resultDigest],
     );
 }
 
 export async function signMessage(signerAccount: SignerWithAddress, message: string) {
-    return signerAccount.signMessage(ethers.utils.arrayify(message));
+    return signerAccount.signMessage(ethers.getBytes(message));
 }
 
 /**

--- a/utils/tools.ts
+++ b/utils/tools.ts
@@ -1,23 +1,8 @@
 // SPDX-FileCopyrightText: 2020-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
-import { assert } from 'chai';
 import type { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
-import { ContractReceipt, Event } from '@ethersproject/contracts';
-
-export function extractEventsFromReceipt(
-    txReceipt: ContractReceipt,
-    address: string,
-    name: string,
-): Event[] {
-    const receiptEvents = txReceipt?.events || [];
-    const events = receiptEvents.filter((event) => {
-        return event.address == address && event.event == name;
-    });
-    assert.isNotEmpty(events, `Fail to extract '${name}' event`);
-    return events;
-}
 
 export function compactSignature(signature: string): string {
     const split = ethers.utils.splitSignature(signature);


### PR DESCRIPTION
See job logs on `Run test` step :heavy_check_mark: :
- https://github.com/iExecBlockchainComputing/PoCo/actions/runs/13311709870/job/37175648195
```
npm run test test/byContract/IexecAccessors/**
[...]
  54 passing (5s)
```