### PR TITLE
feat: implement dataset compatibility check with a deal in `IexecPoco1Facet`

### DIFF
--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -48,9 +48,6 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         return _verifySignatureOrPresignature(_identity, _hash, _signature);
     }
 
-    /***************************************************************************
-     *                  ODB DatasetOrder compatibility with a deal              *
-     ***************************************************************************/
     /**
      * @notice Public view function to check if a dataset order is compatible with a deal.
      * This function performs all the necessary checks to verify dataset order compatibility with a deal.

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -15,6 +15,17 @@ import {IexecEscrow} from "./IexecEscrow.v8.sol";
 import {IexecPocoCommon} from "./IexecPocoCommon.sol";
 import {SignatureVerifier} from "./SignatureVerifier.v8.sol";
 
+struct Matching {
+    bytes32 apporderHash;
+    address appOwner;
+    bytes32 datasetorderHash;
+    address datasetOwner;
+    bytes32 workerpoolorderHash;
+    address workerpoolOwner;
+    bytes32 requestorderHash;
+    bool hasDataset;
+}
+
 contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifier, IexecPocoCommon {
     using Math for uint256;
     using IexecLibOrders_v5 for IexecLibOrders_v5.AppOrder;

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -401,7 +401,7 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         bytes32 datasetOrderHash = _toTypedDataHash(datasetOrder.hash());
         address datasetOwner = IERC5313(datasetOrder.dataset).owner();
         if (!_verifySignatureOrPresignature(datasetOwner, datasetOrderHash, datasetOrder.sign)) {
-            return false; // Invalid signature
+            return false;
         }
 
         // Check if dataset order is not fully consumed
@@ -433,8 +433,6 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         if ((deal.tag & datasetOrder.tag) != datasetOrder.tag) {
             return false;
         }
-
-        // All checks passed
         return true;
     }
 }

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -52,6 +52,9 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
      * @notice Public view function to check if a dataset order is compatible with a deal.
      * This function performs all the necessary checks to verify dataset order compatibility with a deal.
      *
+     * @dev This function is mainly consumed by offchain clients. It should be carefully inspected if used inside on-chain code.
+     * This function should not be used in matchOrders as it does not check the same requirements.
+     *
      * @param datasetOrder The dataset order to verify
      * @param dealid The deal ID to check against
      * @return true if the dataset order is compatible with the deal, false otherwise

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -64,35 +64,29 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         bytes32 dealid
     ) external view override returns (bool) {
         PocoStorageLib.PocoStorage storage $ = PocoStorageLib.getPocoStorage();
-
         // Check if deal exists
         IexecLibCore_v5.Deal storage deal = $.m_deals[dealid];
         if (deal.requester == address(0)) {
             return false;
         }
-
         // Check if deal dataset is address 0 (no dataset in deal)
         if (deal.dataset.pointer != address(0)) {
             return false;
         }
-
         // Check dataset order owner signature (including presign and EIP1271)
         bytes32 datasetOrderHash = _toTypedDataHash(datasetOrder.hash());
         address datasetOwner = IERC5313(datasetOrder.dataset).owner();
         if (!_verifySignatureOrPresignature(datasetOwner, datasetOrderHash, datasetOrder.sign)) {
             return false;
         }
-
         // Check if dataset order is not fully consumed
         if ($.m_consumed[datasetOrderHash] >= datasetOrder.volume) {
             return false;
         }
-
         // Check if deal app is allowed by dataset order apprestrict (including whitelist)
         if (!_isAccountAuthorizedByRestriction(datasetOrder.apprestrict, deal.app.pointer)) {
             return false;
         }
-
         // Check if deal workerpool is allowed by dataset order workerpoolrestrict (including whitelist)
         if (
             !_isAccountAuthorizedByRestriction(
@@ -102,12 +96,10 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         ) {
             return false;
         }
-
         // Check if deal requester is allowed by dataset order requesterrestrict (including whitelist)
         if (!_isAccountAuthorizedByRestriction(datasetOrder.requesterrestrict, deal.requester)) {
             return false;
         }
-
         // Check if deal tag fulfills all the tag bits of the dataset order
         if ((deal.tag & datasetOrder.tag) != datasetOrder.tag) {
             return false;

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -386,7 +386,6 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         PocoStorageLib.PocoStorage storage $ = PocoStorageLib.getPocoStorage();
 
         // Check if deal exists
-        //TODO: check
         IexecLibCore_v5.Deal storage deal = $.m_deals[dealid];
         if (deal.requester == address(0)) {
             return false;

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -69,7 +69,7 @@ contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifie
         if (deal.requester == address(0)) {
             return false;
         }
-        // Check if deal dataset is address 0 (no dataset in deal)
+        // The specified deal should not have a dataset.
         if (deal.dataset.pointer != address(0)) {
             return false;
         }

--- a/contracts/facets/IexecPoco1Facet.sol
+++ b/contracts/facets/IexecPoco1Facet.sol
@@ -15,24 +15,7 @@ import {IexecEscrow} from "./IexecEscrow.v8.sol";
 import {IexecPocoCommon} from "./IexecPocoCommon.sol";
 import {SignatureVerifier} from "./SignatureVerifier.v8.sol";
 
-struct Matching {
-    bytes32 apporderHash;
-    address appOwner;
-    bytes32 datasetorderHash;
-    address datasetOwner;
-    bytes32 workerpoolorderHash;
-    address workerpoolOwner;
-    bytes32 requestorderHash;
-    bool hasDataset;
-}
-
-contract IexecPoco1Facet is
-    IexecPoco1,
-    FacetBase,
-    IexecEscrow,
-    SignatureVerifier,
-    IexecPocoCommon
-{
+contract IexecPoco1Facet is IexecPoco1, FacetBase, IexecEscrow, SignatureVerifier, IexecPocoCommon {
     using Math for uint256;
     using IexecLibOrders_v5 for IexecLibOrders_v5.AppOrder;
     using IexecLibOrders_v5 for IexecLibOrders_v5.DatasetOrder;
@@ -386,5 +369,72 @@ contract IexecPoco1Facet is
         );
 
         return dealid;
+    }
+
+    /**
+     * @notice Public view function to check if a dataset order is compatible with a deal.
+     * This function performs all the necessary checks to verify dataset order compatibility with a deal.
+     *
+     * @param datasetOrder The dataset order to verify
+     * @param dealid The deal ID to check against
+     * @return true if the dataset order is compatible with the deal, false otherwise
+     */
+    function isDatasetCompatibleWithDeal(
+        IexecLibOrders_v5.DatasetOrder calldata datasetOrder,
+        bytes32 dealid
+    ) external view override returns (bool) {
+        PocoStorageLib.PocoStorage storage $ = PocoStorageLib.getPocoStorage();
+
+        // Check if deal exists
+        //TODO: check
+        IexecLibCore_v5.Deal storage deal = $.m_deals[dealid];
+        if (deal.requester == address(0)) {
+            return false;
+        }
+
+        // Check if deal dataset is address 0 (no dataset in deal)
+        if (deal.dataset.pointer != address(0)) {
+            return false;
+        }
+
+        // Check dataset order owner signature (including presign and EIP1271)
+        bytes32 datasetOrderHash = _toTypedDataHash(datasetOrder.hash());
+        address datasetOwner = IERC5313(datasetOrder.dataset).owner();
+        if (!_verifySignatureOrPresignature(datasetOwner, datasetOrderHash, datasetOrder.sign)) {
+            return false; // Invalid signature
+        }
+
+        // Check if dataset order is not fully consumed
+        if ($.m_consumed[datasetOrderHash] >= datasetOrder.volume) {
+            return false;
+        }
+
+        // Check if deal app is allowed by dataset order apprestrict (including whitelist)
+        if (!_isAccountAuthorizedByRestriction(datasetOrder.apprestrict, deal.app.pointer)) {
+            return false;
+        }
+
+        // Check if deal workerpool is allowed by dataset order workerpoolrestrict (including whitelist)
+        if (
+            !_isAccountAuthorizedByRestriction(
+                datasetOrder.workerpoolrestrict,
+                deal.workerpool.pointer
+            )
+        ) {
+            return false;
+        }
+
+        // Check if deal requester is allowed by dataset order requesterrestrict (including whitelist)
+        if (!_isAccountAuthorizedByRestriction(datasetOrder.requesterrestrict, deal.requester)) {
+            return false;
+        }
+
+        // Check if deal tag fulfills all the tag bits of the dataset order
+        if ((deal.tag & datasetOrder.tag) != datasetOrder.tag) {
+            return false;
+        }
+
+        // All checks passed
+        return true;
     }
 }

--- a/contracts/interfaces/IexecPoco1.sol
+++ b/contracts/interfaces/IexecPoco1.sol
@@ -46,4 +46,9 @@ interface IexecPoco1 {
         IexecLibOrders_v5.WorkerpoolOrder calldata,
         IexecLibOrders_v5.RequestOrder calldata
     ) external returns (bytes32);
+
+    function isDatasetCompatibleWithDeal(
+        IexecLibOrders_v5.DatasetOrder calldata datasetOrder,
+        bytes32 dealid
+    ) external view returns (bool);
 }

--- a/contracts/interfaces/IexecPoco1.v8.sol
+++ b/contracts/interfaces/IexecPoco1.v8.sol
@@ -6,6 +6,17 @@ pragma solidity ^0.8.0;
 import {IexecLibOrders_v5} from "../libs/IexecLibOrders_v5.sol";
 
 interface IexecPoco1 {
+    struct Matching {
+        bytes32 apporderHash;
+        address appOwner;
+        bytes32 datasetorderHash;
+        address datasetOwner;
+        bytes32 workerpoolorderHash;
+        address workerpoolOwner;
+        bytes32 requestorderHash;
+        bool hasDataset;
+    }
+
     event SchedulerNotice(address indexed workerpool, bytes32 dealid);
     event OrdersMatched(
         bytes32 dealid,
@@ -40,4 +51,9 @@ interface IexecPoco1 {
         IexecLibOrders_v5.WorkerpoolOrder calldata,
         IexecLibOrders_v5.RequestOrder calldata
     ) external returns (bytes32);
+
+    function isDatasetCompatibleWithDeal(
+        IexecLibOrders_v5.DatasetOrder calldata datasetOrder,
+        bytes32 dealid
+    ) external view returns (bool);
 }

--- a/contracts/interfaces/IexecPoco1.v8.sol
+++ b/contracts/interfaces/IexecPoco1.v8.sol
@@ -15,7 +15,7 @@ interface IexecPoco1 {
         address workerpoolOwner;
         bytes32 requestorderHash;
         bool hasDataset;
-    }
+    };
 
     event SchedulerNotice(address indexed workerpool, bytes32 dealid);
     event OrdersMatched(

--- a/contracts/interfaces/IexecPoco1.v8.sol
+++ b/contracts/interfaces/IexecPoco1.v8.sol
@@ -6,17 +6,6 @@ pragma solidity ^0.8.0;
 import {IexecLibOrders_v5} from "../libs/IexecLibOrders_v5.sol";
 
 interface IexecPoco1 {
-    struct Matching {
-        bytes32 apporderHash;
-        address appOwner;
-        bytes32 datasetorderHash;
-        address datasetOwner;
-        bytes32 workerpoolorderHash;
-        address workerpoolOwner;
-        bytes32 requestorderHash;
-        bool hasDataset;
-    }
-
     event SchedulerNotice(address indexed workerpool, bytes32 dealid);
     event OrdersMatched(
         bytes32 dealid,

--- a/contracts/interfaces/IexecPoco1.v8.sol
+++ b/contracts/interfaces/IexecPoco1.v8.sol
@@ -15,7 +15,7 @@ interface IexecPoco1 {
         address workerpoolOwner;
         bytes32 requestorderHash;
         bool hasDataset;
-    };
+    }
 
     event SchedulerNotice(address indexed workerpool, bytes32 dealid);
     event OrdersMatched(

--- a/scripts/upgrades/deploy-and-update-some-facet.ts
+++ b/scripts/upgrades/deploy-and-update-some-facet.ts
@@ -60,13 +60,10 @@ import { printFunctions } from './upgrade-helper';
     const iexecPocoAccessorsFacet = await factoryDeployer.deployContract(
         iexecPocoAccessorsFacetFactory,
     );
-    console.log(`IexecPocoAccessorsFacet deployed at: ${iexecPocoAccessorsFacet}`);
 
     console.log('Deploying new IexecPoco1Facet...');
     const newIexecPoco1FacetFactory = new IexecPoco1Facet__factory(iexecLibOrders);
-    const newIexecPoco1FacetAddress =
-        await factoryDeployer.deployContract(newIexecPoco1FacetFactory);
-    console.log(`IexecPoco1Facet deployed at: ${newIexecPoco1FacetAddress}`);
+    const newIexecPoco1Facet = await factoryDeployer.deployContract(newIexecPoco1FacetFactory);
 
     console.log(
         '\n=== Step 2: Remove old facets (IexecAccessorsFacet & IexecPocoAccessorsFacet & IexecPoco1Facet) ===',
@@ -153,15 +150,13 @@ import { printFunctions } from './upgrade-helper';
     console.log('New IexecPocoAccessorsFacet added successfully');
 
     console.log('Adding new IexecPoco1Facet ...');
-    await linkContractToProxy(
-        diamondProxyAsOwner,
-        newIexecPoco1FacetAddress,
-        newIexecPoco1FacetFactory,
-    );
+    await linkContractToProxy(diamondProxyAsOwner, newIexecPoco1Facet, newIexecPoco1FacetFactory);
     console.log('New IexecPoco1Facet with isDatasetCompatibleWithDeal added successfully');
 
     console.log('Diamond functions after adding new facets:');
     await printFunctions(diamondProxyAddress);
 
     console.log('\nUpgrade completed successfully!');
+    console.log(`New IexecPocoAccessorsFacet deployed at: ${iexecPocoAccessorsFacet}`);
+    console.log(`New IexecPoco1Facet deployed at: ${newIexecPoco1Facet}`);
 })();

--- a/scripts/upgrades/deploy-and-update-some-facet.ts
+++ b/scripts/upgrades/deploy-and-update-some-facet.ts
@@ -58,7 +58,7 @@ import { printFunctions } from './upgrade-helper';
     console.log('Deploying new IexecPocoAccessorsFacet...');
     const iexecPocoAccessorsFacetFactory = new IexecPocoAccessorsFacet__factory(iexecLibOrders);
     const iexecPocoAccessorsFacet = await factoryDeployer.deployContract(
-        iexecPocoAccessorsFacetFactory,
+        new IexecPocoAccessorsFacet__factory(iexecLibOrders),
     );
 
     console.log('Deploying new IexecPoco1Facet...');

--- a/scripts/upgrades/deploy-and-update-some-facet.ts
+++ b/scripts/upgrades/deploy-and-update-some-facet.ts
@@ -56,9 +56,11 @@ import { printFunctions } from './upgrade-helper';
     };
 
     console.log('Deploying new IexecPocoAccessorsFacet...');
-    const newFacetFactory = new IexecPocoAccessorsFacet__factory(iexecLibOrders);
-    const newFacetAddress = await factoryDeployer.deployContract(newFacetFactory);
-    console.log(`IexecPocoAccessorsFacet deployed at: ${newFacetAddress}`);
+    const iexecPocoAccessorsFacetFactory = new IexecPocoAccessorsFacet__factory(iexecLibOrders);
+    const iexecPocoAccessorsFacet = await factoryDeployer.deployContract(
+        iexecPocoAccessorsFacetFactory,
+    );
+    console.log(`IexecPocoAccessorsFacet deployed at: ${iexecPocoAccessorsFacet}`);
 
     console.log('Deploying new IexecPoco1Facet...');
     const newIexecPoco1FacetFactory = new IexecPoco1Facet__factory(iexecLibOrders);
@@ -143,7 +145,11 @@ import { printFunctions } from './upgrade-helper';
     }
     console.log('\n=== Step 3: Updating diamond proxy with all new facets ===');
     console.log('Adding new IexecPocoAccessorsFacet...');
-    await linkContractToProxy(diamondProxyAsOwner, newFacetAddress, newFacetFactory);
+    await linkContractToProxy(
+        diamondProxyAsOwner,
+        iexecPocoAccessorsFacet,
+        iexecPocoAccessorsFacetFactory,
+    );
     console.log('New IexecPocoAccessorsFacet added successfully');
 
     console.log('Adding new IexecPoco1Facet ...');

--- a/scripts/upgrades/deploy-and-update-some-facet.ts
+++ b/scripts/upgrades/deploy-and-update-some-facet.ts
@@ -158,6 +158,4 @@ import { printFunctions } from './upgrade-helper';
     await printFunctions(diamondProxyAddress);
 
     console.log('\nUpgrade completed successfully!');
-    console.log(`New IexecPocoAccessorsFacet deployed at: ${newFacetAddress}`);
-    console.log(`New IexecPoco1Facet deployed at: ${newIexecPoco1FacetAddress}`);
 })();

--- a/scripts/upgrades/deploy-and-update-some-facet.ts
+++ b/scripts/upgrades/deploy-and-update-some-facet.ts
@@ -4,20 +4,21 @@
 import { ZeroAddress } from 'ethers';
 import { ethers } from 'hardhat';
 import { FacetCutAction } from 'hardhat-deploy/dist/types';
-import type { IDiamond } from '../../../typechain';
+import type { IDiamond } from '../../typechain';
 import {
     DiamondCutFacet__factory,
     DiamondLoupeFacet__factory,
+    IexecPoco1Facet__factory,
     IexecPocoAccessorsFacet__factory,
-} from '../../../typechain';
-import { Ownable__factory } from '../../../typechain/factories/rlc-faucet-contract/contracts';
-import { FactoryDeployer } from '../../../utils/FactoryDeployer';
-import config from '../../../utils/config';
-import { linkContractToProxy } from '../../../utils/proxy-tools';
-import { printFunctions } from '../upgrade-helper';
+} from '../../typechain';
+import { Ownable__factory } from '../../typechain/factories/rlc-faucet-contract/contracts';
+import { FactoryDeployer } from '../../utils/FactoryDeployer';
+import config from '../../utils/config';
+import { linkContractToProxy } from '../../utils/proxy-tools';
+import { printFunctions } from './upgrade-helper';
 
 (async () => {
-    console.log('Deploying and updating IexecPocoAccessorsFacet...');
+    console.log('Deploying and updating IexecPocoAccessorsFacet & IexecPoco1Facet...');
 
     const [account] = await ethers.getSigners();
     const chainId = (await ethers.provider.getNetwork()).chainId;
@@ -47,18 +48,26 @@ import { printFunctions } from '../upgrade-helper';
         proxyOwnerSigner,
     );
 
-    console.log('\n=== Step 1: Deploying new IexecPocoAccessorsFacet ===');
+    console.log('\n=== Step 1: Deploying all new facets ===');
     const factoryDeployer = new FactoryDeployer(account, chainId);
     const iexecLibOrders = {
         ['contracts/libs/IexecLibOrders_v5.sol:IexecLibOrders_v5']:
             deploymentOptions.IexecLibOrders_v5,
     };
 
+    console.log('Deploying new IexecPocoAccessorsFacet...');
     const newFacetFactory = new IexecPocoAccessorsFacet__factory(iexecLibOrders);
     const newFacetAddress = await factoryDeployer.deployContract(newFacetFactory);
+    console.log(`IexecPocoAccessorsFacet deployed at: ${newFacetAddress}`);
+
+    console.log('Deploying new IexecPoco1Facet...');
+    const newIexecPoco1FacetFactory = new IexecPoco1Facet__factory(iexecLibOrders);
+    const newIexecPoco1FacetAddress =
+        await factoryDeployer.deployContract(newIexecPoco1FacetFactory);
+    console.log(`IexecPoco1Facet deployed at: ${newIexecPoco1FacetAddress}`);
 
     console.log(
-        '\n=== Step 2: Remove old facets (remove all functions of old accessors facets) ===',
+        '\n=== Step 2: Remove old facets (IexecAccessorsFacet & IexecPocoAccessorsFacet & IexecPoco1Facet) ===',
     );
 
     const diamondLoupe = DiamondLoupeFacet__factory.connect(diamondProxyAddress, account);
@@ -99,16 +108,17 @@ import { printFunctions } from '../upgrade-helper';
         });
     }
 
-    const oldAccessorFacets = [
+    const oldFacets = [
         '0xEa232be31ab0112916505Aeb7A2a94b5571DCc6b', //IexecAccessorsFacet
         '0xeb40697b275413241d9b31dE568C98B3EA12FFF0', //IexecPocoAccessorsFacet
+        '0x46b555fE117DFd8D4eAC2470FA2d739c6c3a0152', //IexecPoco1Facet
     ];
-    // Remove ALL functions from the old accessor facets using diamondLoupe.facetFunctionSelectors() except of constant founctions
-    for (const facetAddress of oldAccessorFacets) {
+    // Remove ALL functions from the old facets using diamondLoupe.facetFunctionSelectors() except of constant founctions
+    for (const facetAddress of oldFacets) {
         const selectors = await diamondLoupe.facetFunctionSelectors(facetAddress);
         if (selectors.length > 0) {
             console.log(
-                `Removing old accessor facet ${facetAddress} with ${selectors.length} functions - will remove ALL`,
+                `Removing old facet ${facetAddress} with ${selectors.length} functions - will remove ALL`,
             );
             removalCuts.push({
                 facetAddress: ZeroAddress,
@@ -131,12 +141,23 @@ import { printFunctions } from '../upgrade-helper';
         console.log('Diamond functions after removing old facets:');
         await printFunctions(diamondProxyAddress);
     }
-    console.log('\n=== Step 3: Updating diamond proxy with new facet ===');
+    console.log('\n=== Step 3: Updating diamond proxy with all new facets ===');
+    console.log('Adding new IexecPocoAccessorsFacet...');
     await linkContractToProxy(diamondProxyAsOwner, newFacetAddress, newFacetFactory);
-    console.log('New functions added successfully');
+    console.log('New IexecPocoAccessorsFacet added successfully');
 
-    console.log('Diamond functions after adding new facet:');
+    console.log('Adding new IexecPoco1Facet ...');
+    await linkContractToProxy(
+        diamondProxyAsOwner,
+        newIexecPoco1FacetAddress,
+        newIexecPoco1FacetFactory,
+    );
+    console.log('New IexecPoco1Facet with isDatasetCompatibleWithDeal added successfully');
+
+    console.log('Diamond functions after adding new facets:');
     await printFunctions(diamondProxyAddress);
 
     console.log('\nUpgrade completed successfully!');
+    console.log(`New IexecPocoAccessorsFacet deployed at: ${newFacetAddress}`);
+    console.log(`New IexecPoco1Facet deployed at: ${newIexecPoco1FacetAddress}`);
 })();

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1151,7 +1151,6 @@ describe('IexecPoco1', () => {
             );
             await iexecPocoAsRequester.matchOrders(...ordersWithDataset.toArray());
 
-            // Create any dataset order - it should return false because the deal already has a dataset
             expect(
                 await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
                     compatibleDatasetOrder,

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1121,7 +1121,7 @@ describe('IexecPoco1', () => {
             ).to.be.false;
         });
 
-        it('Should return false for deal that already has a dataset', async () => {
+        it('Should return false for deal with a dataset', async () => {
             // Use the original orders that include a dataset to create a deal with dataset
             const ordersWithDataset = buildOrders({
                 assets: ordersAssets, // This includes the dataset

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1111,6 +1111,15 @@ describe('IexecPoco1', () => {
             await signOrder(iexecWrapper.getDomain(), compatibleDatasetOrder, datasetProvider);
         });
 
+        it('Should return true for compatible dataset order', async () => {
+            expect(
+                await iexecPoco.isDatasetCompatibleWithDeal(
+                    compatibleDatasetOrder,
+                    dealIdWithoutDataset,
+                ),
+            ).to.be.true;
+        });
+
         it('Should return false for non-existent deal', async () => {
             const nonExistentDealId = ethers.keccak256(ethers.toUtf8Bytes('non-existent-deal'));
             expect(
@@ -1260,15 +1269,6 @@ describe('IexecPoco1', () => {
                     dealIdWithoutDataset,
                 ),
             ).to.be.false;
-        });
-
-        it('Should return true for compatible dataset order', async () => {
-            expect(
-                await iexecPoco.isDatasetCompatibleWithDeal(
-                    compatibleDatasetOrder,
-                    dealIdWithoutDataset,
-                ),
-            ).to.be.true;
         });
     });
 

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1105,7 +1105,7 @@ describe('IexecPoco1', () => {
                 apprestrict: ordersWithoutDataset.app.app,
                 workerpoolrestrict: ordersWithoutDataset.workerpool.workerpool,
                 requesterrestrict: ordersWithoutDataset.requester.requester,
-                salt: ethers.keccak256(ethers.toUtf8Bytes('compatible-salt')),
+                salt: ethers.id('compatible-salt'),
                 sign: '0x',
             };
             await signOrder(iexecWrapper.getDomain(), compatibleDatasetOrder, datasetProvider);

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1114,7 +1114,7 @@ describe('IexecPoco1', () => {
         it('Should return false for non-existent deal', async () => {
             const nonExistentDealId = ethers.keccak256(ethers.toUtf8Bytes('non-existent-deal'));
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     compatibleDatasetOrder,
                     nonExistentDealId,
                 ),
@@ -1152,7 +1152,7 @@ describe('IexecPoco1', () => {
             await iexecPocoAsRequester.matchOrders(...ordersWithDataset.toArray());
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     compatibleDatasetOrder,
                     dealIdWithDataset,
                 ),
@@ -1167,7 +1167,7 @@ describe('IexecPoco1', () => {
             };
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     invalidSignatureDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1183,7 +1183,7 @@ describe('IexecPoco1', () => {
             await signOrder(iexecWrapper.getDomain(), consumedDatasetOrder, datasetProvider);
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     consumedDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1199,7 +1199,7 @@ describe('IexecPoco1', () => {
             await signOrder(iexecWrapper.getDomain(), incompatibleAppDatasetOrder, datasetProvider);
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     incompatibleAppDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1219,7 +1219,7 @@ describe('IexecPoco1', () => {
             );
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     incompatibleWorkerpoolDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1239,7 +1239,7 @@ describe('IexecPoco1', () => {
             );
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     incompatibleRequesterDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1255,7 +1255,7 @@ describe('IexecPoco1', () => {
             await signOrder(iexecWrapper.getDomain(), incompatibleTagDatasetOrder, datasetProvider);
 
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     incompatibleTagDatasetOrder,
                     dealIdWithoutDataset,
                 ),
@@ -1264,7 +1264,7 @@ describe('IexecPoco1', () => {
 
         it('Should return true for compatible dataset order', async () => {
             expect(
-                await iexecPocoAsSponsor.isDatasetCompatibleWithDeal(
+                await iexecPoco.isDatasetCompatibleWithDeal(
                     compatibleDatasetOrder,
                     dealIdWithoutDataset,
                 ),

--- a/test/byContract/IexecPoco/IexecPoco1.test.ts
+++ b/test/byContract/IexecPoco/IexecPoco1.test.ts
@@ -1121,7 +1121,7 @@ describe('IexecPoco1', () => {
         });
 
         it('Should return false for non-existent deal', async () => {
-            const nonExistentDealId = ethers.keccak256(ethers.toUtf8Bytes('non-existent-deal'));
+            const nonExistentDealId = ethers.id('non-existent-deal');
             expect(
                 await iexecPoco.isDatasetCompatibleWithDeal(
                     compatibleDatasetOrder,
@@ -1141,7 +1141,7 @@ describe('IexecPoco1', () => {
             });
 
             // Use fresh salts to avoid order consumption conflicts
-            ordersWithDataset.app.salt = ethers.keccak256(ethers.toUtf8Bytes('fresh-app-salt'));
+            ordersWithDataset.app.salt = ethers.id('fresh-app-salt');
             ordersWithDataset.dataset.salt = ethers.keccak256(
                 ethers.toUtf8Bytes('fresh-dataset-salt'),
             );


### PR DESCRIPTION
Added a new public view function `isDatasetCompatibleWithDeal` to verify the compatibility of a dataset order with a deal. This function includes multiple checks such as deal existence, dataset order owner signature, and restrictions on app, workerpool, and requester. Removed the `Matching` struct from `IexecPoco1Facet` and moved it to the `IexecPoco1` interface.

<img width="723" height="322" alt="Capture d’écran 2025-09-26 à 11 32 42" src="https://github.com/user-attachments/assets/3ec386ad-ff6d-41e4-b841-f47b2b941d7e" />

**To test** 

1. In one terminal: 

`ARBITRUM_FORK=true npx hardhat node --no-deploy`

1. In another terminal :

```
ARBITRUM_FORK=true npx hardhat run scripts/upgrades/deploy-and-update-some-facet.ts --network external-hardhat
```

