### PR TITLE
fix: Fix `set-callback-gas` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This repository contains the smart contract implementation of iExec's PoCo proto
 ## Documentation
 
 - [Solidity API documentation](./docs/solidity/index.md)
-<!-- TODO update with new documentation URL -->
 - [Full PoCo documentation](https://docs.iex.ec/protocol/proof-of-contribution)
 
 ## Audits

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the smart contract implementation of iExec's PoCo proto
 
 - [Solidity API documentation](./docs/solidity/index.md)
 <!-- TODO update with new documentation URL -->
-- [Full PoCo documentation](https://protocol.docs.iex.ec/key-concepts/proof-of-contribution)
+- [Full PoCo documentation](https://docs.iex.ec/protocol/proof-of-contribution)
 
 ## Audits
 

--- a/deploy/0_deploy.ts
+++ b/deploy/0_deploy.ts
@@ -231,7 +231,7 @@ export default async function deploy() {
     );
     // Verify contracts if not on a development network.
     if (
-        ['hardhat', 'localhost', 'external-hardhat', 'dev-native', 'dev-token'].includes(
+        !['hardhat', 'localhost', 'external-hardhat', 'dev-native', 'dev-token'].includes(
             network.name,
         )
     ) {

--- a/deploy/0_deploy.ts
+++ b/deploy/0_deploy.ts
@@ -229,7 +229,12 @@ export default async function deploy() {
         deployer,
         ownerAddress,
     );
-    if (network.name !== 'hardhat' && network.name !== 'localhost') {
+    // Verify contracts if not on a development network.
+    if (
+        ['hardhat', 'localhost', 'external-hardhat', 'dev-native', 'dev-token'].includes(
+            network.name,
+        )
+    ) {
         console.log('Waiting for block explorer to index the contracts...');
         await new Promise((resolve) => setTimeout(resolve, 60000));
         await import('../scripts/verify').then((module) => module.default());

--- a/scripts/set-callback-gas.ts
+++ b/scripts/set-callback-gas.ts
@@ -1,25 +1,25 @@
 // SPDX-FileCopyrightText: 2024-2025 IEXEC BLOCKCHAIN TECH <contact@iex.ec>
 // SPDX-License-Identifier: Apache-2.0
 
+// Usage: CALLBACK_GAS=<value> npx hardhat run scripts/set-callback-gas.ts --network <network>
+
 import { deployments, ethers } from 'hardhat';
-import { IexecAccessors__factory, IexecConfigurationFacet__factory } from '../typechain';
+import { IexecInterfaceToken__factory } from '../typechain';
 
 (async () => {
     const requestedCallbackGas = Number(process.env.CALLBACK_GAS);
     if (!requestedCallbackGas) {
-        console.error('`CALLBACK_GAS` env variable is missing. Aborting.');
-        process.exit(1);
+        throw new Error('`CALLBACK_GAS` env variable is missing or invalid.');
+    }
+    const diamondProxyAddress = (await deployments.get('Diamond')).address;
+    const [owner] = await ethers.getSigners();
+    const iexecPoCo = IexecInterfaceToken__factory.connect(diamondProxyAddress, owner);
+    if ((await iexecPoCo.owner()) !== owner.address) {
+        throw new Error(`Sender account ${owner.address} is not the PoCo owner.`);
     }
     console.log(`Setting callback-gas to ${requestedCallbackGas.toLocaleString()} ..`);
-    const [owner] = await ethers.getSigners();
-    const diamondProxyAddress = (await deployments.get('Diamond')).address;
-    const viewCallbackGas = async () =>
-        (await IexecAccessors__factory.connect(diamondProxyAddress, owner).callbackgas())
-            .toNumber()
-            .toLocaleString();
-    const callbackGasBefore = await viewCallbackGas();
-    await IexecConfigurationFacet__factory.connect(diamondProxyAddress, owner)
-        .setCallbackGas(requestedCallbackGas)
-        .then((tx) => tx.wait());
-    console.log(`Changed callback-gas from ${callbackGasBefore} to ${await viewCallbackGas()}`);
+    const callbackGasBefore = (await iexecPoCo.callbackgas()).toLocaleString();
+    await iexecPoCo.setCallbackGas(requestedCallbackGas).then((tx) => tx.wait());
+    const callbackGasAfter = (await iexecPoCo.callbackgas()).toLocaleString();
+    console.log(`Changed callback-gas from ${callbackGasBefore} to ${callbackGasAfter}`);
 })().catch((error) => console.log(error));

--- a/scripts/set-callback-gas.ts
+++ b/scripts/set-callback-gas.ts
@@ -22,4 +22,7 @@ import { IexecInterfaceToken__factory } from '../typechain';
     await iexecPoCo.setCallbackGas(requestedCallbackGas).then((tx) => tx.wait());
     const callbackGasAfter = (await iexecPoCo.callbackgas()).toLocaleString();
     console.log(`Changed callback-gas from ${callbackGasBefore} to ${callbackGasAfter}`);
-})().catch((error) => console.log(error));
+})().catch((error) => {
+    console.log(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
### How to test?
Start local Hardhat node:
```sh
$ npx hardhat node
Nothing to compile
No need to generate any newer typings.
Deploying PoCo..
Deployer: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
Network: hardhat (31337)
Deploying new RLC token...
New RLC token deployed at: 0x5FbDB2315678afecb367f032d93F642f64180aa3
[...]
Diamond: 0xeB196D71Bf359bfDB7Ee54429236A09DBF3966B3 
[...]
```

Add chain config in config.json:
```json
    "31337": {
      "asset": "Token",
      "token": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
      "v5": {
        "DiamondProxy": "0xeB196D71Bf359bfDB7Ee54429236A09DBF3966B3"
      }
    },
```

Run script:
```sh
$CALLBACK_GAS=10000 npx hardhat run scripts/set-callback-gas.ts --network localhost
Network: localhost (31337)
Diamond proxy address: 0xeB196D71Bf359bfDB7Ee54429236A09DBF3966B3
Setting callback-gas to 10,000 ..
Changed callback-gas from 100,000 to 10,000
```